### PR TITLE
Implement HMAC verification of ciphertext

### DIFF
--- a/simpl.py
+++ b/simpl.py
@@ -163,17 +163,18 @@ class Locker:
         """ This is called after ever modification to the locker. """
         cipher = AES.new(self.key, AES.MODE_CBC, Random.new().read(AES.block_size))
         with open(SIMPL_PATH, 'wb') as f:
-            plain_text = json.dumps(self.bank).encode('utf8')
-            # Get the HMAC of Locker file
-            hmac = HMAC.new(self.key, msg=plain_text, digestmod=SHA256).digest()
+            plaintext = json.dumps(self.bank).encode('utf8')
             # Pad the data for AES CBC
-            pad_length = AES.block_size - (len(plain_text) % AES.block_size)
+            pad_length = AES.block_size - (len(plaintext) % AES.block_size)
             if pad_length == 0:
                 # Even if it doesn't need the pad, we still add it per PKCS#7
                 pad_length = AES.block_size
             pad = pad_length.to_bytes(1, 'big') * pad_length
-            plain_text += pad
-            f.write(cipher.encrypt(cipher.IV+plain_text)+hmac)
+            plaintext += pad
+            ciphertext = cipher.encrypt(plaintext)
+            # Get the HMAC of Locker file
+            hmac = HMAC.new(self.key, msg=ciphertext, digestmod=SHA256).digest()
+            f.write(cipher.IV+ciphertext+hmac)
         
 class Simpl:
     """ Main Simpl class. """

--- a/simpl.py
+++ b/simpl.py
@@ -146,16 +146,15 @@ class Locker:
         hmac = ciphertext[-32:]
         ciphertext = ciphertext[:-32]
         try:
-            self.bank = cipher.decrypt(ciphertext)
-            # Remove the pad, as per PKCS#7
-            self.bank = self.bank[0:-self.bank[-1]]
-            # Verify the message with the HMAC
-            hmac_msg = HMAC.new(self.key, msg=self.bank, digestmod=SHA256).digest()
+            # Verify message against the HMAC
+            hmac_msg = HMAC.new(self.key, msg=ciphertext, digestmod=SHA256).digest()
             if hmac != hmac_msg:
                 raise ValueError('HMAC could not be verified.')
             else:
-                self.bank = json.loads(self.bank.decode('utf8'))
-        except ValueError as e:
+                self.bank = cipher.decrypt(ciphertext)
+                # Remove the pad, as per PKCS#7, and load json
+                self.bank = json.loads(self.bank[0:-self.bank[-1]].decode('utf8'))
+        except ValueError:
             print("Simpl could not read the locker data. Perhaps you used an invalid key?")
             sys.exit()
 


### PR DESCRIPTION
This implements HMAC verification of the ciphertext instead of the plaintext. This solves some security issues and closes issue #14.
